### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,7 @@ See the `docs/` directory for more details on how it does that.
 
 # Usage
 
-To install:
-
-```
-yarn global add taskcluster-builder
-```
-
-or, to run from the git repository, just use `./taskcluster-builder` as the command below.
+To run from the git repository, just use `./taskcluster-builder`.
 
 # Details
 


### PR DESCRIPTION
There is no `taskcluster-builder` package on neither npm nor yarn. I also removed `as the command below` because I'm not sure what it means. Corrections are welcome!