### PR TITLE
Bug 1504314 - make docker run a little more friendly

### DIFF
--- a/src/build/utils.js
+++ b/src/build/utils.js
@@ -116,23 +116,35 @@ exports.dockerRun = async ({baseDir, logfile, command, env, binds, workingDir, i
   }
 
   const {Binds, Env, ...otherOpts} = dockerRunOpts;
+  const containerOpts = {
+    Image: image,
+    AttachStdin: false,
+    AttachStdout: true,
+    AttachStderr: true,
+    OpenStdin: false,
+    StdinOnce: false,
+    Tty: false,
+    Binds: [...Binds, ...binds || []],
+    Env: [...Env, ...env || []],
+    WorkingDir: workingDir,
+    Cmd: command,
+    ...otherOpts,
+  };
 
-  const runPromise = docker.run(
-    image,
-    command,
-    output,
-    {
-      Binds: [...Binds, ...binds || []],
-      Env: [...Env, ...env || []],
-      WorkingDir: workingDir,
-      ...otherOpts,
-    },
-  );
+  // this is roughly the equivalent of `docker run`, performed as individual
+  // docker API calls.
+  const container = await docker.createContainer(containerOpts);
+  const stream = await container.attach({stream: true, stdout: true, stderr: true});
+  stream.setEncoding('utf-8');
+  stream.pipe(output, {end: true});
+  await container.start({});
 
+  // wait for the output to close, then wait for the container to exit
   await utils.waitFor(output);
-  const container = await utils.waitFor(runPromise);
-  if (container.output.StatusCode !== 0) {
-    throw new Error(`Container exited with status ${container.output.StatusCode}.${errorAddendum}`);
+  const result = await utils.waitFor(container.wait());
+
+  if (result.StatusCode !== 0) {
+    throw new Error(`Container exited with status ${result.StatusCode}.${errorAddendum}`);
   }
 };
 

--- a/src/build/utils.js
+++ b/src/build/utils.js
@@ -124,10 +124,13 @@ exports.dockerRun = async ({baseDir, logfile, command, env, binds, workingDir, i
     OpenStdin: false,
     StdinOnce: false,
     Tty: false,
-    Binds: [...Binds, ...binds || []],
     Env: [...Env, ...env || []],
     WorkingDir: workingDir,
     Cmd: command,
+    HostConfig: {
+      Binds: [...Binds, ...binds || []],
+      AutoRemove: true,
+    },
     ...otherOpts,
   };
 

--- a/taskcluster-spec/build.yml
+++ b/taskcluster-spec/build.yml
@@ -122,7 +122,7 @@ repositories:
     projectName: taskcluster-tools
   service:
     buildtype: tools-ui
-    node: 8
+    node: 10
   source: https://github.com/taskcluster/taskcluster-tools#master
 
 # references (and schemas)


### PR DESCRIPTION
This doesn't solve the bug (for reasons I suggested there), but does a bit of cleanup and makes the `dockerRun` function a little more flexible.  It also builds tools with node 10, which was always expected but is [now required](https://github.com/taskcluster/taskcluster-tools/commit/6485aefd920bcf07e1062844181237ba58eab2e5).