### PR TITLE
Switch to stretch debian

### DIFF
--- a/src/build/service/tools-ui-dockerfile.dot
+++ b/src/build/service/tools-ui-dockerfile.dot
@@ -10,12 +10,11 @@ FROM {{=it.nodeImage}}
 # this is copied from
 #  https://github.com/nginxinc/docker-nginx/blob/590f9ba27d6d11da346440682891bee6694245f5/mainline/stretch/Dockerfile
 # with
-# * stretch -> jessie (the basis for the node image)
 # * gnupg1 -> gnupg2
 # * non-amd64 arch support removed
 
-ENV NGINX_VERSION 1.13.12-1~jessie
-ENV NJS_VERSION   1.13.12.0.2.0-1~jessie
+ENV NGINX_VERSION 1.13.12-1~stretch
+ENV NJS_VERSION   1.13.12.0.2.0-1~stretch
 
 RUN set -x \
        && apt-get update \
@@ -45,7 +44,7 @@ RUN set -x \
        && case "$dpkgArch" in \
                amd64|i386) \
 # arches officialy built by upstream
-                       echo "deb https://nginx.org/packages/mainline/debian/ jessie nginx" >> /etc/apt/sources.list.d/nginx.list \
+                       echo "deb https://nginx.org/packages/mainline/debian/ stretch nginx" >> /etc/apt/sources.list.d/nginx.list \
                        && apt-get update \
                        ;; \
                *) \


### PR DESCRIPTION
Apparently, the node 10 image that we use is a stretch, because without this change the image build process will fail with the error:

```bash
The command '/bin/sh -c set -x        && apt-get update        && apt-get install --no-install-recommends --no-install-suggests -y gnupg2 apt-transport-https ca-certificates        &&        NGINX_GPGKEY=573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62;        found='';        for server in                ha.pool.sks-keyservers.net                hkp://keyserver.ubuntu.com:80                hkp://p80.pool.sks-keyservers.net:80                pgp.mit.edu        ; do                echo "Fetching GPG key $NGINX_GPGKEY from $server";                apt-key adv --keyserver "$server" --no-tty --keyserver-options timeout=10 --recv-keys "$NGINX_GPGKEY" && found=yes && break;        done;        test -z "$found" && echo >&2 "error: failed to fetch GPG key $NGINX_GPGKEY" && exit 1;        apt-get remove --purge --auto-remove -y gnupg2 && rm -rf /var/lib/apt/lists/*        && dpkgArch="$(dpkg --print-architecture)"        && nginxPackages="                nginx=${NGINX_VERSION}                nginx-module-xslt=${NGINX_VERSION}                nginx-module-geoip=${NGINX_VERSION}                nginx-module-image-filter=${NGINX_VERSION}                nginx-module-njs=${NJS_VERSION}        "        && case "$dpkgArch" in                amd64|i386)                        echo "deb https://nginx.org/packages/mainline/debian/ jessie nginx" >> /etc/apt/sources.list.d/nginx.list                        && apt-get update                        ;;                *)             echo "unsupported architecture" && exit 1             ;;        esac               && apt-get install --no-install-recommends --no-install-suggests -y                                                $nginxPackages                                                gettext-base        && apt-get remove --purge --auto-remove -y apt-transport-https ca-certificates && rm -rf /var/lib/apt/lists/* /etc/apt/sources.list.d/nginx.list               && if [ -n "$tempDir" ]; then                apt-get purge -y --auto-remove                && rm -rf "$tempDir" /etc/apt/sources.list.d/temp.list;        fi' returned a non-zero code: 100
```

(I wonder what would the long-term fix be here tho)