### PR TITLE
Don't autoremove, as it causes container-not-found errors

### DIFF
--- a/src/build/utils.js
+++ b/src/build/utils.js
@@ -129,7 +129,9 @@ exports.dockerRun = async ({baseDir, logfile, command, env, binds, workingDir, i
     Cmd: command,
     HostConfig: {
       Binds: [...Binds, ...binds || []],
-      AutoRemove: true,
+      // AutoRemove would help clean up stray containers, but means we cannot reliably
+      // get the exit status of the container
+      AutoRemove: false,
     },
     ...otherOpts,
   };
@@ -145,6 +147,7 @@ exports.dockerRun = async ({baseDir, logfile, command, env, binds, workingDir, i
   // wait for the output to close, then wait for the container to exit
   await utils.waitFor(output);
   const result = await utils.waitFor(container.wait());
+  await utils.waitFor(container.remove());
 
   if (result.StatusCode !== 0) {
     throw new Error(`Container exited with status ${result.StatusCode}.${errorAddendum}`);


### PR DESCRIPTION
Autoremove is equivalent to `docker run --rm`, and was causing a race
condition where we tried to check the exit status of a container after
it closed its stdout stream, but Docker was removing the container at
the same time.

This approach is more likely to leave containers lying around when the
user hits ctrl-C while running tc-builder, but those are easily cleaned
up with `docker container purge`.